### PR TITLE
Up metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Flags:
 * `logstash_node_queue_max_size_bytes` (counter)
 * `logstash_node_queue_max_unread_events`: queue_max_ (counter)
 * `logstash_node_queue_page_capacity_bytes`: queue_page_capacity_bytes (counter)
+* `logstash_node_up`: whether logstash node is up (1) or not (0) (gauge)
 
 ## Integration tests
 In order to execute manual integration tests (to know if certain logstash version is compatible with logstash-exporter), you can follow instructions present on file [integration-tests/README.md](integration-tests/README.md).

--- a/collector/api_base.go
+++ b/collector/api_base.go
@@ -2,8 +2,9 @@ package collector
 
 import (
 	"encoding/json"
-	"github.com/prometheus/common/log"
 	"net/http"
+
+	"github.com/prometheus/common/log"
 )
 
 // HTTPHandler type
@@ -29,20 +30,20 @@ type HTTPHandlerInterface interface {
 func getMetrics(h HTTPHandlerInterface, target interface{}) error {
 	response, err := h.Get()
 	if err != nil {
-		log.Errorf("Cannot retrieve metrics: %s", err)
-		return nil
+		log.Errorf("Cannot retrieve metrics: %v", err)
+		return err
 	}
 
 	defer func() {
-		err = response.Body.Close()
-		if err != nil {
+		if err := response.Body.Close(); err != nil {
 			log.Errorf("Cannot close response body: %v", err)
 		}
 	}()
 
-	if err := json.NewDecoder(response.Body).Decode(target); err != nil {
-		log.Errorf("Cannot parse Logstash response json: %s", err)
+	err = json.NewDecoder(response.Body).Decode(target)
+	if err != nil {
+		log.Errorf("Cannot parse Logstash response json: %v", err)
 	}
 
-	return nil
+	return err
 }

--- a/collector/nodeinfo_collector.go
+++ b/collector/nodeinfo_collector.go
@@ -1,9 +1,9 @@
 package collector
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // NodeInfoCollector type
@@ -47,17 +47,9 @@ func NewNodeInfoCollector(logstashEndpoint string) (Collector, error) {
 
 // Collect function implements nodestats_collector collector
 func (c *NodeInfoCollector) Collect(ch chan<- prometheus.Metric) error {
-	if desc, err := c.collect(ch); err != nil {
-		log.Error("Failed collecting info metrics", desc, err)
-		return err
-	}
-	return nil
-}
-
-func (c *NodeInfoCollector) collect(ch chan<- prometheus.Metric) (*prometheus.Desc, error) {
 	stats, err := NodeInfo(c.endpoint)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	ch <- prometheus.MustNewConstMetric(
@@ -86,5 +78,5 @@ func (c *NodeInfoCollector) collect(ch chan<- prometheus.Metric) (*prometheus.De
 		stats.Jvm.VMVendor,
 	)
 
-	return nil, nil
+	return nil
 }

--- a/logstash_exporter.go
+++ b/logstash_exporter.go
@@ -88,7 +88,7 @@ func execute(name string, c collector.Collector, ch chan<- prometheus.Metric) {
 	var result string
 
 	if err != nil {
-		log.Errorf("ERROR: %s collector failed after %fs: %s", name, duration.Seconds(), err)
+		log.Debugf("ERROR: %s collector failed after %fs: %s", name, duration.Seconds(), err)
 		result = "error"
 	} else {
 		log.Debugf("OK: %s collector succeeded after %fs.", name, duration.Seconds())


### PR DESCRIPTION
Fixes issue https://github.com/BonnierNews/logstash_exporter/issues/18 and implements metric `logstash_node_up` to know if `logstash-exporter` can communicate with `logstash` (as proposed on https://github.com/BonnierNews/logstash_exporter/issues/13)