### PR TITLE
clean up Dockerfile for a working build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,37 @@
-FROM golang:1.11 as golang
-ARG GODEP_VERSION=v0.5.0
+# See: https://hub.docker.com/_/golang/
+FROM golang:latest as golang
 
-RUN curl -fsSL -o /usr/local/bin/dep https://github.com/golang/dep/releases/download/${GODEP_VERSION}/dep-linux-amd64 && \
-        chmod +x /usr/local/bin/dep && \
-        go get -u github.com/sequra/logstash_exporter && \
-        cd $GOPATH/src/github.com/sequra/logstash_exporter && \
-        dep ensure && \
+# See: https://github.com/golang/dep/releases
+ARG GODEP_VERSION=v0.5.0
+ARG GOLINT_VERSION=v1.15.0
+
+##
+# We break up the monolithic command so the cacheability for each layer/step is better
+##
+# Download `dep` into /usr/local/bin/dep. Follow re-directs, and be as silent aspossible; output if errors
+RUN curl --fail --silent --show-error --location --output /usr/local/bin/dep https://github.com/golang/dep/releases/download/${GODEP_VERSION}/dep-linux-amd64 && \
+        chmod +x /usr/local/bin/dep
+
+# Download the golang linter cli binary
+# See: https://github.com/golangci/golangci-lint#ci-installation
+RUN curl --silent --fail --location https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLINT_VERSION}
+
+# Fetch the source
+RUN go get -u github.com/sequra/logstash_exporter
+
+# Fetch the source and dependencies
+RUN cd $GOPATH/src/github.com/sequra/logstash_exporter && \
+        dep init && \
+        dep ensure
+
+# Build!
+RUN cd $GOPATH/src/github.com/sequra/logstash_exporter && \
         make
 
-FROM busybox:1.30.0-glibc
+# It looks like the `latest` tag uses uclibc
+# See: https://hub.docker.com/_/busybox/
+FROM busybox:latest 
 COPY --from=golang /go/src/github.com/sequra/logstash_exporter/logstash_exporter /
 LABEL maintainer devops@sequra.es
 EXPOSE 9198
-ENTRYPOINT ["/logstash_exporter"]  
+ENTRYPOINT ["/logstash_exporter"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:latest as golang
 
 # See: https://github.com/golang/dep/releases
 ARG GODEP_VERSION=v0.5.0
+# See: https://github.com/golangci/golangci-lint/releases
 ARG GOLINT_VERSION=v1.15.0
 
 ##
@@ -19,7 +20,7 @@ RUN curl --silent --fail --location https://install.goreleaser.com/github.com/go
 # Fetch the source
 RUN go get -u github.com/sequra/logstash_exporter
 
-# Fetch the source and dependencies
+# Fetch dependencies
 RUN cd $GOPATH/src/github.com/sequra/logstash_exporter && \
         dep init && \
         dep ensure


### PR DESCRIPTION
Both the `golang` and `busybox` containers use the `latest` tag.
This gets us an UTD golang version as well as a `uclibc` busybox container
which should result in a (slightly) smaller deployment container.

the `RUN` commands have been broken up to improve caching.
the short form arguments on `curl` calls have been converted into
long-form to improve readability.

some comments added to improve maintainability.

golint is now installed in the container. It was used in the `Makefile`
but not installed in the container... creating errors on build